### PR TITLE
Add global vehicle support search bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 site/**/*.html
 site/sitemap.xml
 site/css/main.css
+site/vehicle-search-index.json
 discord_message.txt
 
 .swiftpm/

--- a/generator/Sources/gensite/gensite.swift
+++ b/generator/Sources/gensite/gensite.swift
@@ -261,6 +261,12 @@ struct Gensite: AsyncParsableCommand {
           makesToGenerate = allMakes
         }
 
+        // Generate vehicle search index (only when not filtering)
+        if make == nil,
+           model == nil {
+          try VehicleSearchIndex.generate(supportMatrix: supportMatrix, outputURL: outputURL)
+        }
+
         // Only generate the make grid page if not filtering by make or model
         if make == nil,
            model == nil {

--- a/generator/Sources/gensite/pages/SupportedCars/Components/VehicleSearchBar.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/Components/VehicleSearchBar.swift
@@ -37,7 +37,7 @@ struct VehicleSearchBar: View {
       Div {
         // Results will be populated by JavaScript
       }
-      .identifier("vehicle-search-results")
+      .id("vehicle-search-results")
       .classNames([
         "absolute", "z-50", "w-full", "mt-2", "max-h-96", "overflow-y-auto",
         "bg-white", "dark:bg-zinc-800",

--- a/generator/Sources/gensite/pages/SupportedCars/Components/VehicleSearchBar.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/Components/VehicleSearchBar.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Slipstream
+
+struct VehicleSearchBar: View {
+  var body: some View {
+    Div {
+      // Search input container
+      Div {
+        // Search icon
+        Div {
+          DOMString(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+            </svg>
+            """
+          )
+        }
+        .classNames(["absolute", "left-4", "top-1/2", "-translate-y-1/2", "text-zinc-400", "pointer-events-none"])
+
+        // Search input field
+        DOMString(
+          """
+          <input
+            type="text"
+            id="vehicle-search-input"
+            placeholder="Search makes and models..."
+            autocomplete="off"
+            class="w-full pl-12 pr-4 py-3 text-base md:text-lg rounded-2xl border-2 border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+          />
+          """
+        )
+      }
+      .position(.relative)
+
+      // Dropdown results container (hidden by default)
+      Div {
+        // Results will be populated by JavaScript
+      }
+      .identifier("vehicle-search-results")
+      .classNames([
+        "absolute", "z-50", "w-full", "mt-2", "max-h-96", "overflow-y-auto",
+        "bg-white", "dark:bg-zinc-800",
+        "border-2", "border-zinc-200", "dark:border-zinc-700",
+        "rounded-2xl", "shadow-lg",
+        "hidden"  // Hidden by default, shown by JavaScript when there are results
+      ])
+    }
+    .position(.relative)
+    .classNames(["w-full", "max-w-2xl", "mx-auto"])
+  }
+}

--- a/generator/Sources/gensite/pages/SupportedCars/Components/VehicleSearchBar.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/Components/VehicleSearchBar.swift
@@ -4,32 +4,41 @@ import Slipstream
 struct VehicleSearchBar: View {
   var body: some View {
     Div {
-      // Search input container
+      // Search input container with icon
       Div {
-        // Search icon
+        // Search icon (SVG)
         Div {
-          DOMString(
-            """
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
-            </svg>
-            """
-          )
+          SVG {
+            SVGPath()
+              .attribute("stroke-linecap", "round")
+              .attribute("stroke-linejoin", "round")
+              .attribute("d", "m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z")
+          }
+          .attribute("xmlns", "http://www.w3.org/2000/svg")
+          .attribute("fill", "none")
+          .attribute("viewBox", "0 0 24 24")
+          .attribute("stroke-width", "1.5")
+          .attribute("stroke", "currentColor")
+          .classNames(["w-5", "h-5"])
         }
         .classNames(["absolute", "left-4", "top-1/2", "-translate-y-1/2", "text-zinc-400", "pointer-events-none"])
 
         // Search input field
-        DOMString(
-          """
-          <input
-            type="text"
-            id="vehicle-search-input"
-            placeholder="Search makes and models..."
-            autocomplete="off"
-            class="w-full pl-12 pr-4 py-3 text-base md:text-lg rounded-2xl border-2 border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
-          />
-          """
-        )
+        Input(type: .text)
+          .id("vehicle-search-input")
+          .attribute("placeholder", "Search makes and models...")
+          .attribute("autocomplete", "off")
+          .classNames([
+            "w-full", "pl-12", "pr-4", "py-3",
+            "text-base", "md:text-lg",
+            "rounded-2xl",
+            "border-2", "border-zinc-200", "dark:border-zinc-700",
+            "bg-white", "dark:bg-zinc-900",
+            "text-zinc-900", "dark:text-zinc-100",
+            "placeholder-zinc-400",
+            "focus:outline-none", "focus:ring-2", "focus:ring-blue-500", "focus:border-transparent",
+            "transition-all"
+          ])
       }
       .position(.relative)
 

--- a/generator/Sources/gensite/pages/SupportedCars/Components/VehicleSearchBar.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/Components/VehicleSearchBar.swift
@@ -36,7 +36,7 @@ struct VehicleSearchBar: View {
     try input.attr("id", "vehicle-search-input")
     try input.attr("placeholder", "Search makes and models...")
     try input.attr("autocomplete", "off")
-    try input.addClass("w-full pl-12 pr-4 py-3 text-base md:text-lg rounded-2xl border-2 border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all")
+    try input.addClass("w-full pl-12 pr-4 py-3 text-base md:text-lg rounded-2xl border-2 border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-600 focus:border-transparent transition-all")
 
     // Dropdown results container (hidden by default)
     let resultsDiv = try mainDiv.appendElement("div")

--- a/generator/Sources/gensite/pages/SupportedCars/Components/VehicleSearchBar.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/Components/VehicleSearchBar.swift
@@ -1,61 +1,46 @@
 import Foundation
 import Slipstream
+import SwiftSoup
 
 struct VehicleSearchBar: View {
-  var body: some View {
-    Div {
-      // Search input container with icon
-      Div {
-        // Search icon (SVG)
-        Div {
-          SVG {
-            SVGPath()
-              .attribute("stroke-linecap", "round")
-              .attribute("stroke-linejoin", "round")
-              .attribute("d", "m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z")
-          }
-          .attribute("xmlns", "http://www.w3.org/2000/svg")
-          .attribute("fill", "none")
-          .attribute("viewBox", "0 0 24 24")
-          .attribute("stroke-width", "1.5")
-          .attribute("stroke", "currentColor")
-          .classNames(["w-5", "h-5"])
-        }
-        .classNames(["absolute", "left-4", "top-1/2", "-translate-y-1/2", "text-zinc-400", "pointer-events-none"])
+  func render(_ container: SwiftSoup.Element, environment: EnvironmentValues) throws {
+    // Main container
+    let mainDiv = try container.appendElement("div")
+    try mainDiv.addClass("relative w-full max-w-2xl mx-auto")
 
-        // Search input field
-        Input(type: .text)
-          .id("vehicle-search-input")
-          .attribute("placeholder", "Search makes and models...")
-          .attribute("autocomplete", "off")
-          .classNames([
-            "w-full", "pl-12", "pr-4", "py-3",
-            "text-base", "md:text-lg",
-            "rounded-2xl",
-            "border-2", "border-zinc-200", "dark:border-zinc-700",
-            "bg-white", "dark:bg-zinc-900",
-            "text-zinc-900", "dark:text-zinc-100",
-            "placeholder-zinc-400",
-            "focus:outline-none", "focus:ring-2", "focus:ring-blue-500", "focus:border-transparent",
-            "transition-all"
-          ])
-      }
-      .position(.relative)
+    // Search input container
+    let inputContainer = try mainDiv.appendElement("div")
+    try inputContainer.addClass("relative")
 
-      // Dropdown results container (hidden by default)
-      Div {
-        // Results will be populated by JavaScript
-      }
-      .id("vehicle-search-results")
-      .classNames([
-        "absolute", "z-50", "w-full", "mt-2", "max-h-96", "overflow-y-auto",
-        "bg-white", "dark:bg-zinc-800",
-        "border-2", "border-zinc-200", "dark:border-zinc-700",
-        "rounded-2xl", "shadow-lg",
-        "hidden"  // Hidden by default, shown by JavaScript when there are results
-      ])
-    }
-    .position(.relative)
-    .classNames(["w-full", "max-w-2xl", "mx-auto"])
+    // Search icon container
+    let iconDiv = try inputContainer.appendElement("div")
+    try iconDiv.addClass("absolute left-4 top-1/2 -translate-y-1/2 text-zinc-400 pointer-events-none")
+
+    // Search icon (SVG)
+    let svg = try iconDiv.appendElement("svg")
+    try svg.attr("xmlns", "http://www.w3.org/2000/svg")
+    try svg.attr("fill", "none")
+    try svg.attr("viewBox", "0 0 24 24")
+    try svg.attr("stroke-width", "1.5")
+    try svg.attr("stroke", "currentColor")
+    try svg.addClass("w-5 h-5")
+
+    let path = try svg.appendElement("path")
+    try path.attr("stroke-linecap", "round")
+    try path.attr("stroke-linejoin", "round")
+    try path.attr("d", "m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z")
+
+    // Search input field
+    let input = try inputContainer.appendElement("input")
+    try input.attr("type", "text")
+    try input.attr("id", "vehicle-search-input")
+    try input.attr("placeholder", "Search makes and models...")
+    try input.attr("autocomplete", "off")
+    try input.addClass("w-full pl-12 pr-4 py-3 text-base md:text-lg rounded-2xl border-2 border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all")
+
+    // Dropdown results container (hidden by default)
+    let resultsDiv = try mainDiv.appendElement("div")
+    try resultsDiv.attr("id", "vehicle-search-results")
+    try resultsDiv.addClass("absolute z-50 w-full mt-2 max-h-96 overflow-y-auto bg-white dark:bg-zinc-800 border-2 border-zinc-200 dark:border-zinc-700 rounded-2xl shadow-lg hidden")
   }
 }

--- a/generator/Sources/gensite/pages/SupportedCars/Components/VehicleSearchBar.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/Components/VehicleSearchBar.swift
@@ -25,7 +25,7 @@ struct VehicleSearchBar: View {
     try svg.attr("stroke", "currentColor")
     try svg.addClass("w-5 h-5")
 
-    let path = try svg.appendElement("path")
+    let path = try svg.appendslement("path")
     try path.attr("stroke-linecap", "round")
     try path.attr("stroke-linejoin", "round")
     try path.attr("d", "m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z")

--- a/generator/Sources/gensite/pages/SupportedCars/Make/MakePage.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/Make/MakePage.swift
@@ -68,8 +68,6 @@ struct MakePage: View {
         .padding(.vertical, 16)
         .position(.sticky)
         .classNames(["top-0", "z-40"])
-        .border(.init(.zinc, darkness: 200), width: 1, edges: .bottom)
-        .border(.init(.zinc, darkness: 800), width: 1, edges: .bottom, condition: .dark)
       }
 
       ContentContainer {

--- a/generator/Sources/gensite/pages/SupportedCars/Make/MakePage.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/Make/MakePage.swift
@@ -60,6 +60,18 @@ struct MakePage: View {
       ],
       scripts: [URL(string: "/scripts/vehicle-search.js")]
     ) {
+      // Search bar - always visible, sticky at top
+      Section {
+        ContentContainer {
+          VehicleSearchBar()
+        }
+        .padding(.vertical, 16)
+        .position(.sticky)
+        .classNames(["top-0", "z-40"])
+        .border(.init(.zinc, darkness: 200), width: 1, edges: .bottom)
+        .border(.init(.zinc, darkness: 800), width: 1, edges: .bottom, condition: .dark)
+      }
+
       ContentContainer {
         VStack(alignment: .center) {
           HStack(spacing: 32) {
@@ -80,20 +92,6 @@ struct MakePage: View {
           .textAlignment(.center)
         }
         .padding(.vertical, 16)
-      }
-
-      // Search bar - always visible, sticky below header
-      Section {
-        ContentContainer {
-          VehicleSearchBar()
-        }
-        .padding(.vertical, 16)
-        .background(.white)
-        .background(.zinc, darkness: 950, condition: .dark)
-        .position(.sticky)
-        .classNames(["top-0", "z-40"])
-        .border(.init(.zinc, darkness: 200), width: 1, edges: .bottom)
-        .border(.init(.zinc, darkness: 800), width: 1, edges: .bottom, condition: .dark)
       }
 
       Section {

--- a/generator/Sources/gensite/pages/SupportedCars/Make/MakePage.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/Make/MakePage.swift
@@ -57,7 +57,8 @@ struct MakePage: View {
         "trip logger",
         "vehicle diagnostics",
         "vehicle connectivity",
-      ]
+      ],
+      scripts: [URL(string: "/scripts/vehicle-search.js")]
     ) {
       ContentContainer {
         VStack(alignment: .center) {
@@ -79,6 +80,20 @@ struct MakePage: View {
           .textAlignment(.center)
         }
         .padding(.vertical, 16)
+      }
+
+      // Search bar - always visible, sticky below header
+      Section {
+        ContentContainer {
+          VehicleSearchBar()
+        }
+        .padding(.vertical, 16)
+        .background(.white)
+        .background(.zinc, darkness: 950, condition: .dark)
+        .position(.sticky)
+        .classNames(["top-0", "z-40"])
+        .border(.init(.zinc, darkness: 200), edges: .bottom, width: 1)
+        .border(.init(.zinc, darkness: 800), edges: .bottom, width: 1, condition: .dark)
       }
 
       Section {

--- a/generator/Sources/gensite/pages/SupportedCars/Make/MakePage.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/Make/MakePage.swift
@@ -92,8 +92,8 @@ struct MakePage: View {
         .background(.zinc, darkness: 950, condition: .dark)
         .position(.sticky)
         .classNames(["top-0", "z-40"])
-        .border(.init(.zinc, darkness: 200), edges: .bottom, width: 1)
-        .border(.init(.zinc, darkness: 800), edges: .bottom, width: 1, condition: .dark)
+        .border(.init(.zinc, darkness: 200), width: 1, edges: .bottom)
+        .border(.init(.zinc, darkness: 800), width: 1, edges: .bottom, condition: .dark)
       }
 
       Section {

--- a/generator/Sources/gensite/pages/SupportedCars/MakeGridPage.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/MakeGridPage.swift
@@ -64,8 +64,8 @@ struct MakeGridPage: View {
         .background(.zinc, darkness: 950, condition: .dark)
         .position(.sticky)
         .classNames(["top-0", "z-40"])
-        .border(.init(.zinc, darkness: 200), edges: .bottom, width: 1)
-        .border(.init(.zinc, darkness: 800), edges: .bottom, width: 1, condition: .dark)
+        .border(.init(.zinc, darkness: 200), width: 1, edges: .bottom)
+        .border(.init(.zinc, darkness: 800), width: 1, edges: .bottom, condition: .dark)
       }
 
       Section {

--- a/generator/Sources/gensite/pages/SupportedCars/MakeGridPage.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/MakeGridPage.swift
@@ -37,6 +37,18 @@ struct MakeGridPage: View {
       ],
       scripts: [URL(string: "/scripts/vehicle-search.js")]
     ) {
+      // Search bar - always visible, sticky at top
+      Section {
+        ContentContainer {
+          VehicleSearchBar()
+        }
+        .padding(.vertical, 16)
+        .position(.sticky)
+        .classNames(["top-0", "z-40"])
+        .border(.init(.zinc, darkness: 200), width: 1, edges: .bottom)
+        .border(.init(.zinc, darkness: 800), width: 1, edges: .bottom, condition: .dark)
+      }
+
       ContentContainer {
         VStack(alignment: .center) {
           HeroIconPuck(url: URL(string: "/gfx/supported-vehicle.png")!)
@@ -52,20 +64,6 @@ struct MakeGridPage: View {
           .textAlignment(.center)
         }
         .padding(.vertical, 16)
-      }
-
-      // Search bar - always visible, sticky below header
-      Section {
-        ContentContainer {
-          VehicleSearchBar()
-        }
-        .padding(.vertical, 16)
-        .background(.white)
-        .background(.zinc, darkness: 950, condition: .dark)
-        .position(.sticky)
-        .classNames(["top-0", "z-40"])
-        .border(.init(.zinc, darkness: 200), width: 1, edges: .bottom)
-        .border(.init(.zinc, darkness: 800), width: 1, edges: .bottom, condition: .dark)
       }
 
       Section {

--- a/generator/Sources/gensite/pages/SupportedCars/MakeGridPage.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/MakeGridPage.swift
@@ -34,7 +34,8 @@ struct MakeGridPage: View {
         "trip logger",
         "vehicle diagnostics",
         "vehicle connectivity",
-      ]
+      ],
+      scripts: [URL(string: "/scripts/vehicle-search.js")]
     ) {
       ContentContainer {
         VStack(alignment: .center) {
@@ -51,6 +52,20 @@ struct MakeGridPage: View {
           .textAlignment(.center)
         }
         .padding(.vertical, 16)
+      }
+
+      // Search bar - always visible, sticky below header
+      Section {
+        ContentContainer {
+          VehicleSearchBar()
+        }
+        .padding(.vertical, 16)
+        .background(.white)
+        .background(.zinc, darkness: 950, condition: .dark)
+        .position(.sticky)
+        .classNames(["top-0", "z-40"])
+        .border(.init(.zinc, darkness: 200), edges: .bottom, width: 1)
+        .border(.init(.zinc, darkness: 800), edges: .bottom, width: 1, condition: .dark)
       }
 
       Section {

--- a/generator/Sources/gensite/pages/SupportedCars/MakeGridPage.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/MakeGridPage.swift
@@ -45,8 +45,6 @@ struct MakeGridPage: View {
         .padding(.vertical, 16)
         .position(.sticky)
         .classNames(["top-0", "z-40"])
-        .border(.init(.zinc, darkness: 200), width: 1, edges: .bottom)
-        .border(.init(.zinc, darkness: 800), width: 1, edges: .bottom, condition: .dark)
       }
 
       ContentContainer {

--- a/generator/Sources/gensite/pages/SupportedCars/Model/ModelPage.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/Model/ModelPage.swift
@@ -91,6 +91,18 @@ struct ModelPage: View {
         ],
         scripts: [URL(string: "/scripts/vehicle-search.js")]
       ) {
+        // Search bar - always visible, sticky at top
+        Section {
+          ContentContainer {
+            VehicleSearchBar()
+          }
+          .padding(.vertical, 16)
+          .position(.sticky)
+          .classNames(["top-0", "z-40"])
+          .border(.init(.zinc, darkness: 200), width: 1, edges: .bottom)
+          .border(.init(.zinc, darkness: 800), width: 1, edges: .bottom, condition: .dark)
+        }
+
         ContentContainer {
           VStack(alignment: .center) {
             HStack(spacing: 32) {
@@ -123,20 +135,6 @@ struct ModelPage: View {
             .textAlignment(.center)
           }
           .padding(.vertical, 16)
-        }
-
-        // Search bar - always visible, sticky below header
-        Section {
-          ContentContainer {
-            VehicleSearchBar()
-          }
-          .padding(.vertical, 16)
-          .background(.white)
-          .background(.zinc, darkness: 950, condition: .dark)
-          .position(.sticky)
-          .classNames(["top-0", "z-40"])
-          .border(.init(.zinc, darkness: 200), width: 1, edges: .bottom)
-          .border(.init(.zinc, darkness: 800), width: 1, edges: .bottom, condition: .dark)
         }
 
         // Feature Support Table - Above the fold for better SEO

--- a/generator/Sources/gensite/pages/SupportedCars/Model/ModelPage.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/Model/ModelPage.swift
@@ -135,8 +135,8 @@ struct ModelPage: View {
           .background(.zinc, darkness: 950, condition: .dark)
           .position(.sticky)
           .classNames(["top-0", "z-40"])
-          .border(.init(.zinc, darkness: 200), edges: .bottom, width: 1)
-          .border(.init(.zinc, darkness: 800), edges: .bottom, width: 1, condition: .dark)
+          .border(.init(.zinc, darkness: 200), width: 1, edges: .bottom)
+          .border(.init(.zinc, darkness: 800), width: 1, edges: .bottom, condition: .dark)
         }
 
         // Feature Support Table - Above the fold for better SEO

--- a/generator/Sources/gensite/pages/SupportedCars/Model/ModelPage.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/Model/ModelPage.swift
@@ -99,8 +99,6 @@ struct ModelPage: View {
           .padding(.vertical, 16)
           .position(.sticky)
           .classNames(["top-0", "z-40"])
-          .border(.init(.zinc, darkness: 200), width: 1, edges: .bottom)
-          .border(.init(.zinc, darkness: 800), width: 1, edges: .bottom, condition: .dark)
         }
 
         ContentContainer {

--- a/generator/Sources/gensite/pages/SupportedCars/Model/ModelPage.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/Model/ModelPage.swift
@@ -88,7 +88,8 @@ struct ModelPage: View {
           "trip logger",
           "vehicle diagnostics",
           "vehicle connectivity",
-        ]
+        ],
+        scripts: [URL(string: "/scripts/vehicle-search.js")]
       ) {
         ContentContainer {
           VStack(alignment: .center) {
@@ -122,6 +123,20 @@ struct ModelPage: View {
             .textAlignment(.center)
           }
           .padding(.vertical, 16)
+        }
+
+        // Search bar - always visible, sticky below header
+        Section {
+          ContentContainer {
+            VehicleSearchBar()
+          }
+          .padding(.vertical, 16)
+          .background(.white)
+          .background(.zinc, darkness: 950, condition: .dark)
+          .position(.sticky)
+          .classNames(["top-0", "z-40"])
+          .border(.init(.zinc, darkness: 200), edges: .bottom, width: 1)
+          .border(.init(.zinc, darkness: 800), edges: .bottom, width: 1, condition: .dark)
         }
 
         // Feature Support Table - Above the fold for better SEO

--- a/generator/Sources/gensite/pages/SupportedCars/VehicleSearchIndex.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/VehicleSearchIndex.swift
@@ -1,0 +1,70 @@
+import Foundation
+import VehicleSupportMatrix
+
+struct VehicleSearchIndex {
+  struct VehicleEntry: Codable {
+    let make: String
+    let makeSlug: String
+    let model: String
+    let modelSlug: String
+    let url: String
+    let iconPath: String
+  }
+
+  struct SearchIndex: Codable {
+    let vehicles: [VehicleEntry]
+  }
+
+  static func generate(supportMatrix: MergedSupportMatrix, outputURL: URL) throws {
+    var vehicles: [VehicleEntry] = []
+
+    let makes = supportMatrix.getAllMakes()
+
+    for make in makes {
+      let makeSlug = makeNameForSorting(make)
+      let iconPath = "/gfx/make/\(makeNameForIcon(make)).svg"
+
+      // Add entry for the make itself
+      vehicles.append(VehicleEntry(
+        make: make,
+        makeSlug: makeSlug,
+        model: "",
+        modelSlug: "",
+        url: "/supported-cars/\(makeSlug)/",
+        iconPath: iconPath
+      ))
+
+      // Add entries for each model
+      for obdbID in supportMatrix.getOBDbIDs(for: make) {
+        guard let modelSupport = supportMatrix.getModel(id: obdbID) else {
+          continue
+        }
+
+        let modelSlug = modelNameForURL(modelSupport.model)
+        let modelIconPath = !modelSupport.modelSVGs.isEmpty
+          ? "/gfx/vehicle/\(modelSupport.modelSVGs[0])"
+          : "/gfx/placeholder-car.png"
+
+        vehicles.append(VehicleEntry(
+          make: make,
+          makeSlug: makeSlug,
+          model: modelSupport.model,
+          modelSlug: modelSlug,
+          url: "/supported-cars/\(makeSlug)/\(modelSlug)/",
+          iconPath: modelIconPath
+        ))
+      }
+    }
+
+    let searchIndex = SearchIndex(vehicles: vehicles)
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let jsonData = try encoder.encode(searchIndex)
+
+    let searchIndexURL = outputURL.appending(path: "vehicle-search-index.json")
+    try jsonData.write(to: searchIndexURL)
+
+    print("Generated vehicle-search-index.json with \(vehicles.count) entries")
+  }
+}

--- a/generator/Sources/gensite/pages/SupportedCars/VehicleSearchIndex.swift
+++ b/generator/Sources/gensite/pages/SupportedCars/VehicleSearchIndex.swift
@@ -3,63 +3,87 @@ import VehicleSupportMatrix
 
 struct VehicleSearchIndex {
   struct VehicleEntry: Codable {
-    let make: String
-    let makeSlug: String
-    let model: String
-    let modelSlug: String
-    let url: String
-    let iconPath: String
+    let m: Int     // make index
+    let n: String  // model name
+    let s: String  // model slug (empty for make-only entries)
+    let i: String? // icon (relative path) - omitted for placeholder
+    let t: String? // icon type (m=make, v=vehicle) - omitted for placeholder
+  }
+
+  struct Make: Codable {
+    let n: String // make name
+    let s: String // makeSlug
+    let i: String // icon filename
   }
 
   struct SearchIndex: Codable {
-    let vehicles: [VehicleEntry]
+    let m: [Make]           // makes
+    let v: [VehicleEntry]   // vehicles
   }
 
   static func generate(supportMatrix: MergedSupportMatrix, outputURL: URL) throws {
     var vehicles: [VehicleEntry] = []
+    var makesArray: [Make] = []
+    var makeIndexMap: [String: Int] = [:]
 
-    let makes = supportMatrix.getAllMakes()
+    let makeNames = supportMatrix.getAllMakes()
 
-    for make in makes {
-      let makeSlug = makeNameForSorting(make)
-      let iconPath = "/gfx/make/\(makeNameForIcon(make)).svg"
+    // Build the makes array and index map
+    for (index, makeName) in makeNames.enumerated() {
+      let makeSlug = makeNameForSorting(makeName)
+      let iconName = makeNameForIcon(makeName)
 
-      // Add entry for the make itself
+      makesArray.append(Make(
+        n: makeName,
+        s: makeSlug,
+        i: iconName + ".svg"
+      ))
+      makeIndexMap[makeName] = index
+    }
+
+    for makeName in makeNames {
+      guard let makeIndex = makeIndexMap[makeName] else {
+        continue
+      }
+
+      let makeSlug = makeNameForSorting(makeName)
+
+      // Add entry for the make itself (empty model name and slug)
       vehicles.append(VehicleEntry(
-        make: make,
-        makeSlug: makeSlug,
-        model: "",
-        modelSlug: "",
-        url: "/supported-cars/\(makeSlug)/",
-        iconPath: iconPath
+        m: makeIndex,
+        n: "",
+        s: "",
+        i: nil,
+        t: "m"
       ))
 
       // Add entries for each model
-      for obdbID in supportMatrix.getOBDbIDs(for: make) {
+      for obdbID in supportMatrix.getOBDbIDs(for: makeName) {
         guard let modelSupport = supportMatrix.getModel(id: obdbID) else {
           continue
         }
 
         let modelSlug = modelNameForURL(modelSupport.model)
-        let modelIconPath = !modelSupport.modelSVGs.isEmpty
-          ? "/gfx/vehicle/\(modelSupport.modelSVGs[0])"
-          : "/gfx/placeholder-car.png"
+
+        // Only include icon properties if not using placeholder
+        let (icon, iconType): (String?, String?) = !modelSupport.modelSVGs.isEmpty
+          ? (modelSupport.modelSVGs[0], "v")
+          : (nil, nil)
 
         vehicles.append(VehicleEntry(
-          make: make,
-          makeSlug: makeSlug,
-          model: modelSupport.model,
-          modelSlug: modelSlug,
-          url: "/supported-cars/\(makeSlug)/\(modelSlug)/",
-          iconPath: modelIconPath
+          m: makeIndex,
+          n: modelSupport.model,
+          s: modelSlug,
+          i: icon,
+          t: iconType
         ))
       }
     }
 
-    let searchIndex = SearchIndex(vehicles: vehicles)
+    let searchIndex = SearchIndex(m: makesArray, v: vehicles)
 
     let encoder = JSONEncoder()
-    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    encoder.outputFormatting = [.sortedKeys]
     let jsonData = try encoder.encode(searchIndex)
 
     let searchIndexURL = outputURL.appending(path: "vehicle-search-index.json")

--- a/site/scripts/vehicle-search.js
+++ b/site/scripts/vehicle-search.js
@@ -1,6 +1,8 @@
 (function() {
   'use strict';
 
+  console.log('[Vehicle Search] Script initializing...');
+
   let searchIndex = null;
   let selectedIndex = -1;
   let filteredResults = [];
@@ -8,19 +10,30 @@
   const searchInput = document.getElementById('vehicle-search-input');
   const resultsContainer = document.getElementById('vehicle-search-results');
 
+  console.log('[Vehicle Search] DOM elements:', {
+    searchInput: searchInput ? 'Found' : 'Not found',
+    resultsContainer: resultsContainer ? 'Found' : 'Not found'
+  });
+
   if (!searchInput || !resultsContainer) {
+    console.warn('[Vehicle Search] Required DOM elements not found, exiting');
     return; // Search components not present on this page
   }
 
   // Load the search index
+  console.log('[Vehicle Search] Fetching search index from /vehicle-search-index.json');
   fetch('/vehicle-search-index.json')
-    .then(response => response.json())
+    .then(response => {
+      console.log('[Vehicle Search] Fetch response:', response.status, response.statusText);
+      return response.json();
+    })
     .then(data => {
       searchIndex = data.vehicles;
-      console.log('Vehicle search index loaded:', searchIndex.length, 'entries');
+      console.log('[Vehicle Search] Index loaded successfully:', searchIndex.length, 'entries');
+      console.log('[Vehicle Search] First 3 entries:', searchIndex.slice(0, 3));
     })
     .catch(error => {
-      console.error('Failed to load vehicle search index:', error);
+      console.error('[Vehicle Search] Failed to load search index:', error);
     });
 
   // Debounce function to limit search frequency
@@ -38,12 +51,17 @@
 
   // Search and filter vehicles
   function searchVehicles(query) {
+    console.log('[Vehicle Search] searchVehicles called with query:', query);
+    console.log('[Vehicle Search] Search index loaded?', searchIndex !== null);
+
     if (!searchIndex || !query.trim()) {
+      console.log('[Vehicle Search] Hiding results - no index or empty query');
       hideResults();
       return;
     }
 
     const lowerQuery = query.toLowerCase();
+    console.log('[Vehicle Search] Searching for:', lowerQuery);
 
     // Filter vehicles - search in make and model
     filteredResults = searchIndex.filter(vehicle => {
@@ -53,21 +71,28 @@
       return makeMatch || modelMatch || combinedMatch;
     });
 
+    console.log('[Vehicle Search] Found', filteredResults.length, 'results before limiting');
+
     // Limit to top 10 results
     filteredResults = filteredResults.slice(0, 10);
 
+    console.log('[Vehicle Search] Showing', filteredResults.length, 'results');
     selectedIndex = filteredResults.length > 0 ? 0 : -1;
     displayResults();
   }
 
   // Display search results
   function displayResults() {
+    console.log('[Vehicle Search] displayResults called with', filteredResults.length, 'results');
+
     if (filteredResults.length === 0) {
+      console.log('[Vehicle Search] No results, showing "No vehicles found" message');
       resultsContainer.innerHTML = '<div class="px-4 py-3 text-zinc-500 dark:text-zinc-400">No vehicles found</div>';
       resultsContainer.classList.remove('hidden');
       return;
     }
 
+    console.log('[Vehicle Search] Rendering results dropdown');
     resultsContainer.innerHTML = filteredResults.map((vehicle, index) => {
       const isSelected = index === selectedIndex;
       const isMakeOnly = !vehicle.model;
@@ -152,11 +177,16 @@
   }
 
   // Event listeners
+  console.log('[Vehicle Search] Setting up event listeners');
+
   searchInput.addEventListener('input', debounce((e) => {
+    console.log('[Vehicle Search] Input event fired, value:', e.target.value);
     searchVehicles(e.target.value);
   }, 200));
 
   searchInput.addEventListener('keydown', handleKeyDown);
+
+  console.log('[Vehicle Search] Event listeners attached successfully');
 
   // Close results when clicking outside
   document.addEventListener('click', (e) => {
@@ -169,4 +199,6 @@
   resultsContainer.addEventListener('mousedown', (e) => {
     e.preventDefault(); // Prevent input from losing focus
   });
+
+  console.log('[Vehicle Search] Initialization complete');
 })();

--- a/site/scripts/vehicle-search.js
+++ b/site/scripts/vehicle-search.js
@@ -131,6 +131,14 @@ document.addEventListener('DOMContentLoaded', function() {
         navigateToSelected(index);
       });
     });
+
+    // Scroll selected item into view
+    if (selectedIndex >= 0 && resultElements[selectedIndex]) {
+      resultElements[selectedIndex].scrollIntoView({
+        block: 'nearest',
+        behavior: 'smooth'
+      });
+    }
   }
 
   // Hide results

--- a/site/scripts/vehicle-search.js
+++ b/site/scripts/vehicle-search.js
@@ -48,16 +48,22 @@ document.addEventListener('DOMContentLoaded', function() {
       return;
     }
 
-    const lowerQuery = query.toLowerCase();
-    console.log('[Vehicle Search] Searching for:', lowerQuery);
+    // Normalize text for searching (remove spaces, hyphens, and lowercase)
+    const normalizeForSearch = (text) => text.toLowerCase().replace(/[\s\-]/g, '');
+
+    const normalizedQuery = normalizeForSearch(query);
+    console.log('[Vehicle Search] Searching for:', query, '(normalized:', normalizedQuery + ')');
 
     // Filter vehicles - search in make and model
     filteredResults = searchIndex.filter(vehicle => {
       const make = makesArray[vehicle.m];
-      const makeMatch = make.n.toLowerCase().includes(lowerQuery);
-      const modelMatch = vehicle.n.toLowerCase().includes(lowerQuery);
-      const combinedMatch = `${make.n} ${vehicle.n}`.toLowerCase().includes(lowerQuery);
-      return makeMatch || modelMatch || combinedMatch;
+      const normalizedMake = normalizeForSearch(make.n);
+      const normalizedModel = normalizeForSearch(vehicle.n);
+      const normalizedCombined = normalizeForSearch(`${make.n} ${vehicle.n}`);
+
+      return normalizedMake.includes(normalizedQuery) ||
+             normalizedModel.includes(normalizedQuery) ||
+             normalizedCombined.includes(normalizedQuery);
     });
 
     console.log('[Vehicle Search] Found', filteredResults.length, 'results before limiting');
@@ -115,7 +121,22 @@ document.addEventListener('DOMContentLoaded', function() {
             <div class="font-bold text-base truncate">
               ${make.n}${vehicle.n ? ` ${vehicle.n}` : ''}
             </div>
-            ${isMakeOnly ? '<div class="text-sm opacity-80">View all models</div>' : ''}
+            <div class="text-sm opacity-70">
+              ${(() => {
+                const hasDrivers = vehicle.d != null && vehicle.d > 0;
+                const hasMiles = vehicle.k != null && vehicle.k > 0;
+
+                if (!hasDrivers && !hasMiles) {
+                  return 'No drivers yet';
+                } else if (hasDrivers && !hasMiles) {
+                  return `${vehicle.d.toLocaleString()} driver${vehicle.d !== 1 ? 's' : ''} · No miles driven yet`;
+                } else if (!hasDrivers && hasMiles) {
+                  return `No drivers · ${vehicle.k.toLocaleString()}k miles`;
+                } else {
+                  return `${vehicle.d.toLocaleString()} driver${vehicle.d !== 1 ? 's' : ''} · ${vehicle.k.toLocaleString()}k miles`;
+                }
+              })()}
+            </div>
           </div>
         </a>
       `;

--- a/site/scripts/vehicle-search.js
+++ b/site/scripts/vehicle-search.js
@@ -35,19 +35,6 @@ document.addEventListener('DOMContentLoaded', function() {
       console.error('[Vehicle Search] Failed to load search index:', error);
     });
 
-  // Debounce function to limit search frequency
-  function debounce(func, wait) {
-    let timeout;
-    return function executedFunction(...args) {
-      const later = () => {
-        clearTimeout(timeout);
-        func(...args);
-      };
-      clearTimeout(timeout);
-      timeout = setTimeout(later, wait);
-    };
-  }
-
   // Search and filter vehicles
   function searchVehicles(query) {
     console.log('[Vehicle Search] searchVehicles called with query:', query);
@@ -195,10 +182,10 @@ document.addEventListener('DOMContentLoaded', function() {
   // Event listeners
   console.log('[Vehicle Search] Setting up event listeners');
 
-  searchInput.addEventListener('input', debounce((e) => {
+  searchInput.addEventListener('input', (e) => {
     console.log('[Vehicle Search] Input event fired, value:', e.target.value);
     searchVehicles(e.target.value);
-  }, 200));
+  });
 
   searchInput.addEventListener('keydown', handleKeyDown);
 

--- a/site/scripts/vehicle-search.js
+++ b/site/scripts/vehicle-search.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', function() {
   console.log('[Vehicle Search] DOM loaded, initializing search...');
 
   let searchIndex = null;
+  let makesArray = null;
   let selectedIndex = -1;
   let filteredResults = [];
 
@@ -27,8 +28,9 @@ document.addEventListener('DOMContentLoaded', function() {
       return response.json();
     })
     .then(data => {
-      searchIndex = data.vehicles;
-      console.log('[Vehicle Search] Index loaded successfully:', searchIndex.length, 'entries');
+      makesArray = data.m;
+      searchIndex = data.v;
+      console.log('[Vehicle Search] Index loaded successfully:', makesArray.length, 'makes,', searchIndex.length, 'entries');
       console.log('[Vehicle Search] First 3 entries:', searchIndex.slice(0, 3));
     })
     .catch(error => {
@@ -51,9 +53,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Filter vehicles - search in make and model
     filteredResults = searchIndex.filter(vehicle => {
-      const makeMatch = vehicle.make.toLowerCase().includes(lowerQuery);
-      const modelMatch = vehicle.model.toLowerCase().includes(lowerQuery);
-      const combinedMatch = `${vehicle.make} ${vehicle.model}`.toLowerCase().includes(lowerQuery);
+      const make = makesArray[vehicle.m];
+      const makeMatch = make.n.toLowerCase().includes(lowerQuery);
+      const modelMatch = vehicle.n.toLowerCase().includes(lowerQuery);
+      const combinedMatch = `${make.n} ${vehicle.n}`.toLowerCase().includes(lowerQuery);
       return makeMatch || modelMatch || combinedMatch;
     });
 
@@ -81,12 +84,21 @@ document.addEventListener('DOMContentLoaded', function() {
     console.log('[Vehicle Search] Rendering results dropdown');
     resultsContainer.innerHTML = filteredResults.map((vehicle, index) => {
       const isSelected = index === selectedIndex;
-      const isMakeOnly = !vehicle.model;
-      const isPlaceholder = vehicle.iconPath.includes('placeholder-car.png');
+      const make = makesArray[vehicle.m];
+      const isMakeOnly = !vehicle.n;
+      const isPlaceholder = !vehicle.i;
+
+      // Reconstruct full paths from compact format
+      const iconPath = vehicle.t === 'm' ? `/gfx/make/${make.i}` :
+                       vehicle.t === 'v' ? `/gfx/vehicle/${vehicle.i}` :
+                       `/gfx/placeholder-car.png`;
+      const url = vehicle.s
+        ? `/supported-cars/${make.s}/${vehicle.s}/`
+        : `/supported-cars/${make.s}/`;
 
       return `
         <a
-          href="${vehicle.url}"
+          href="${url}"
           class="vehicle-search-result cursor-pointer flex items-center gap-3 px-4 py-3 transition-colors ${
             isSelected
               ? 'bg-blue-500 text-white'
@@ -95,13 +107,13 @@ document.addEventListener('DOMContentLoaded', function() {
           data-index="${index}"
         >
           <img
-            src="${vehicle.iconPath}"
-            alt="${vehicle.make} ${vehicle.model}"
+            src="${iconPath}"
+            alt="${make.n} ${vehicle.n}"
             class="w-8 ${isPlaceholder ? 'p-2' : ''} ${isSelected ? 'invert brightness-0' : 'dark:invert'}"
           />
           <div class="flex-1 min-w-0">
             <div class="font-bold text-base truncate">
-              ${vehicle.make}${vehicle.model ? ` ${vehicle.model}` : ''}
+              ${make.n}${vehicle.n ? ` ${vehicle.n}` : ''}
             </div>
             ${isMakeOnly ? '<div class="text-sm opacity-80">View all models</div>' : ''}
           </div>
@@ -148,7 +160,12 @@ document.addEventListener('DOMContentLoaded', function() {
   // Navigate to selected result
   function navigateToSelected(index = selectedIndex) {
     if (index >= 0 && index < filteredResults.length) {
-      window.location.href = filteredResults[index].url;
+      const vehicle = filteredResults[index];
+      const make = makesArray[vehicle.m];
+      const url = vehicle.s
+        ? `/supported-cars/${make.s}/${vehicle.s}/`
+        : `/supported-cars/${make.s}/`;
+      window.location.href = url;
     }
   }
 

--- a/site/scripts/vehicle-search.js
+++ b/site/scripts/vehicle-search.js
@@ -101,15 +101,15 @@ document.addEventListener('DOMContentLoaded', function() {
           href="${url}"
           class="vehicle-search-result cursor-pointer flex items-center gap-3 px-4 py-3 transition-colors ${
             isSelected
-              ? 'bg-blue-500 text-white'
-              : 'hover:bg-zinc-100 dark:hover:bg-zinc-700 text-zinc-900 dark:text-zinc-100'
+              ? 'bg-zinc-200 dark:bg-zinc-700 text-zinc-900 dark:text-zinc-100'
+              : 'hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-900 dark:text-zinc-100'
           }"
           data-index="${index}"
         >
           <img
             src="${iconPath}"
             alt="${make.n} ${vehicle.n}"
-            class="w-8 ${isPlaceholder ? 'p-2' : ''} ${isSelected ? 'invert brightness-0' : 'dark:invert'}"
+            class="w-8 ${isPlaceholder ? 'p-2' : ''} ${isSelected ? '' : 'dark:invert'}"
           />
           <div class="flex-1 min-w-0">
             <div class="font-bold text-base truncate">

--- a/site/scripts/vehicle-search.js
+++ b/site/scripts/vehicle-search.js
@@ -110,7 +110,7 @@ document.addEventListener('DOMContentLoaded', function() {
           <img
             src="${vehicle.iconPath}"
             alt="${vehicle.make} ${vehicle.model}"
-            class="w-8 ${isPlaceholder ? 'p-2' : ''} ${isSelected ? '' : 'dark:invert'}"
+            class="w-8 ${isPlaceholder ? 'p-2' : ''} ${isSelected ? 'invert' : 'dark:invert'}"
           />
           <div class="flex-1 min-w-0">
             <div class="font-bold text-base truncate">
@@ -132,10 +132,12 @@ document.addEventListener('DOMContentLoaded', function() {
         navigateToSelected(index);
       });
 
-      // Update selection on hover
+      // Update selection on hover (only if it actually changed to prevent re-render loops)
       element.addEventListener('mouseenter', () => {
-        selectedIndex = index;
-        displayResults();
+        if (selectedIndex !== index) {
+          selectedIndex = index;
+          displayResults();
+        }
       });
     });
 

--- a/site/scripts/vehicle-search.js
+++ b/site/scripts/vehicle-search.js
@@ -1,0 +1,172 @@
+(function() {
+  'use strict';
+
+  let searchIndex = null;
+  let selectedIndex = -1;
+  let filteredResults = [];
+
+  const searchInput = document.getElementById('vehicle-search-input');
+  const resultsContainer = document.getElementById('vehicle-search-results');
+
+  if (!searchInput || !resultsContainer) {
+    return; // Search components not present on this page
+  }
+
+  // Load the search index
+  fetch('/vehicle-search-index.json')
+    .then(response => response.json())
+    .then(data => {
+      searchIndex = data.vehicles;
+      console.log('Vehicle search index loaded:', searchIndex.length, 'entries');
+    })
+    .catch(error => {
+      console.error('Failed to load vehicle search index:', error);
+    });
+
+  // Debounce function to limit search frequency
+  function debounce(func, wait) {
+    let timeout;
+    return function executedFunction(...args) {
+      const later = () => {
+        clearTimeout(timeout);
+        func(...args);
+      };
+      clearTimeout(timeout);
+      timeout = setTimeout(later, wait);
+    };
+  }
+
+  // Search and filter vehicles
+  function searchVehicles(query) {
+    if (!searchIndex || !query.trim()) {
+      hideResults();
+      return;
+    }
+
+    const lowerQuery = query.toLowerCase();
+
+    // Filter vehicles - search in make and model
+    filteredResults = searchIndex.filter(vehicle => {
+      const makeMatch = vehicle.make.toLowerCase().includes(lowerQuery);
+      const modelMatch = vehicle.model.toLowerCase().includes(lowerQuery);
+      const combinedMatch = `${vehicle.make} ${vehicle.model}`.toLowerCase().includes(lowerQuery);
+      return makeMatch || modelMatch || combinedMatch;
+    });
+
+    // Limit to top 10 results
+    filteredResults = filteredResults.slice(0, 10);
+
+    selectedIndex = filteredResults.length > 0 ? 0 : -1;
+    displayResults();
+  }
+
+  // Display search results
+  function displayResults() {
+    if (filteredResults.length === 0) {
+      resultsContainer.innerHTML = '<div class="px-4 py-3 text-zinc-500 dark:text-zinc-400">No vehicles found</div>';
+      resultsContainer.classList.remove('hidden');
+      return;
+    }
+
+    resultsContainer.innerHTML = filteredResults.map((vehicle, index) => {
+      const isSelected = index === selectedIndex;
+      const isMakeOnly = !vehicle.model;
+
+      return `
+        <a
+          href="${vehicle.url}"
+          class="vehicle-search-result flex items-center gap-3 px-4 py-3 transition-colors ${
+            isSelected
+              ? 'bg-blue-500 text-white'
+              : 'hover:bg-zinc-100 dark:hover:bg-zinc-700 text-zinc-900 dark:text-zinc-100'
+          }"
+          data-index="${index}"
+        >
+          <img
+            src="${vehicle.iconPath}"
+            alt="${vehicle.make} ${vehicle.model}"
+            class="w-8 h-8 ${isSelected ? '' : 'dark:invert'}"
+          />
+          <div class="flex-1 min-w-0">
+            <div class="font-bold text-base truncate">
+              ${vehicle.make}${vehicle.model ? ` ${vehicle.model}` : ''}
+            </div>
+            ${isMakeOnly ? '<div class="text-sm opacity-80">View all models</div>' : ''}
+          </div>
+        </a>
+      `;
+    }).join('');
+
+    resultsContainer.classList.remove('hidden');
+
+    // Add click handlers to results
+    const resultElements = resultsContainer.querySelectorAll('.vehicle-search-result');
+    resultElements.forEach((element, index) => {
+      element.addEventListener('click', (e) => {
+        e.preventDefault();
+        navigateToSelected(index);
+      });
+    });
+  }
+
+  // Hide results
+  function hideResults() {
+    resultsContainer.classList.add('hidden');
+    resultsContainer.innerHTML = '';
+    filteredResults = [];
+    selectedIndex = -1;
+  }
+
+  // Navigate to selected result
+  function navigateToSelected(index = selectedIndex) {
+    if (index >= 0 && index < filteredResults.length) {
+      window.location.href = filteredResults[index].url;
+    }
+  }
+
+  // Handle keyboard navigation
+  function handleKeyDown(e) {
+    if (!resultsContainer.classList.contains('hidden') && filteredResults.length > 0) {
+      switch(e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          selectedIndex = (selectedIndex + 1) % filteredResults.length;
+          displayResults();
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          selectedIndex = selectedIndex <= 0 ? filteredResults.length - 1 : selectedIndex - 1;
+          displayResults();
+          break;
+        case 'Enter':
+          e.preventDefault();
+          navigateToSelected();
+          break;
+        case 'Escape':
+          e.preventDefault();
+          hideResults();
+          searchInput.blur();
+          break;
+      }
+    }
+  }
+
+  // Event listeners
+  searchInput.addEventListener('input', debounce((e) => {
+    searchVehicles(e.target.value);
+  }, 200));
+
+  searchInput.addEventListener('keydown', handleKeyDown);
+
+  // Close results when clicking outside
+  document.addEventListener('click', (e) => {
+    if (!searchInput.contains(e.target) && !resultsContainer.contains(e.target)) {
+      hideResults();
+    }
+  });
+
+  // Focus input when clicking on results container
+  resultsContainer.addEventListener('mousedown', (e) => {
+    e.preventDefault(); // Prevent input from losing focus
+  });
+})();

--- a/site/scripts/vehicle-search.js
+++ b/site/scripts/vehicle-search.js
@@ -1,7 +1,6 @@
-(function() {
-  'use strict';
-
-  console.log('[Vehicle Search] Script initializing...');
+// Wait for DOM to be ready before initializing search
+document.addEventListener('DOMContentLoaded', function() {
+  console.log('[Vehicle Search] DOM loaded, initializing search...');
 
   let searchIndex = null;
   let selectedIndex = -1;
@@ -201,4 +200,4 @@
   });
 
   console.log('[Vehicle Search] Initialization complete');
-})();
+});

--- a/site/scripts/vehicle-search.js
+++ b/site/scripts/vehicle-search.js
@@ -97,7 +97,7 @@ document.addEventListener('DOMContentLoaded', function() {
           <img
             src="${vehicle.iconPath}"
             alt="${vehicle.make} ${vehicle.model}"
-            class="w-8 ${isPlaceholder ? 'p-2' : ''} ${isSelected ? 'invert' : 'dark:invert'}"
+            class="w-8 ${isPlaceholder ? 'p-2' : ''} ${isSelected ? 'invert brightness-0' : 'dark:invert'}"
           />
           <div class="flex-1 min-w-0">
             <div class="font-bold text-base truncate">

--- a/site/scripts/vehicle-search.js
+++ b/site/scripts/vehicle-search.js
@@ -95,11 +95,12 @@ document.addEventListener('DOMContentLoaded', function() {
     resultsContainer.innerHTML = filteredResults.map((vehicle, index) => {
       const isSelected = index === selectedIndex;
       const isMakeOnly = !vehicle.model;
+      const isPlaceholder = vehicle.iconPath.includes('placeholder-car.png');
 
       return `
         <a
           href="${vehicle.url}"
-          class="vehicle-search-result flex items-center gap-3 px-4 py-3 transition-colors ${
+          class="vehicle-search-result cursor-pointer flex items-center gap-3 px-4 py-3 transition-colors ${
             isSelected
               ? 'bg-blue-500 text-white'
               : 'hover:bg-zinc-100 dark:hover:bg-zinc-700 text-zinc-900 dark:text-zinc-100'
@@ -109,7 +110,7 @@ document.addEventListener('DOMContentLoaded', function() {
           <img
             src="${vehicle.iconPath}"
             alt="${vehicle.make} ${vehicle.model}"
-            class="w-8 h-8 ${isSelected ? '' : 'dark:invert'}"
+            class="w-8 ${isPlaceholder ? 'p-2' : ''} ${isSelected ? '' : 'dark:invert'}"
           />
           <div class="flex-1 min-w-0">
             <div class="font-bold text-base truncate">
@@ -123,12 +124,18 @@ document.addEventListener('DOMContentLoaded', function() {
 
     resultsContainer.classList.remove('hidden');
 
-    // Add click handlers to results
+    // Add click and hover handlers to results
     const resultElements = resultsContainer.querySelectorAll('.vehicle-search-result');
     resultElements.forEach((element, index) => {
       element.addEventListener('click', (e) => {
         e.preventDefault();
         navigateToSelected(index);
+      });
+
+      // Update selection on hover
+      element.addEventListener('mouseenter', () => {
+        selectedIndex = index;
+        displayResults();
       });
     });
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./site/**/*.html"],
+  content: ["./site/**/*.html", "./site/**/*.js"],
   theme: {
     extend: {
       boxShadow: {


### PR DESCRIPTION
Implemented a fast, client-side vehicle search feature:

- Created JSON index builder that generates a precompiled search index during site generation for instant client-side searching
- Added VehicleSearchBar component that appears sticky below the header on all supported cars pages (make grid, make pages, and model pages)
- Implemented autocomplete JavaScript with keyboard navigation:
  - Search filters both makes and models as you type
  - Up/down arrow keys navigate through results
  - Enter key navigates to selected vehicle
  - Escape key closes the dropdown
- Search bar is always visible and sticky-positioned for easy access
- Fully responsive design with dark mode support