### PR TITLE
Write Hyundai Elantra model article

### DIFF
--- a/articles/hyundai/elantra/about.md
+++ b/articles/hyundai/elantra/about.md
@@ -1,0 +1,33 @@
+# About the Hyundai Elantra
+
+The Hyundai Elantra is a compact sedan known for its value, fuel efficiency, and modern technology features. First introduced in 1990, the Elantra has evolved into one of Hyundai's best-selling models worldwide.
+
+## Frequently Asked Questions
+
+### Does the Hyundai Elantra support Apple CarPlay and Android Auto?
+
+Apple CarPlay and Android Auto support varies by model year and screen size:
+
+**2024-2025 Models:**
+- **8-inch touchscreen**: **Wireless** Apple CarPlay and Android Auto (standard on base configurations)
+- **10.25-inch touchscreen**: **Wired-only** Apple CarPlay and Android Auto (available on higher configurations)
+
+Interestingly, the base model with the smaller 8-inch screen offers wireless connectivity, while the premium configurations with the larger 10.25-inch display require a wired USB connection.
+
+**2022-2023 Models:**
+- **Wireless** Apple CarPlay and Android Auto available on configurations with 8-inch touchscreen
+- **Wired** Apple CarPlay and Android Auto on configurations with 10.25-inch touchscreen
+- Wireless support first introduced in 2022 model year
+
+**2017-2021 Models:**
+- **Wired-only** Apple CarPlay and Android Auto (USB connection required)
+- Available on most configurations starting with 2017 model year
+- Aftermarket wireless adapters available to add wireless functionality
+
+**2016 and Earlier:**
+- No Apple CarPlay or Android Auto support
+- Aftermarket solutions may be available
+
+For models with only wired connectivity, aftermarket wireless adapters are available that plug into the existing USB port and enable wireless functionality without modification to the vehicle.
+
+[View Elantra technology features](https://www.hyundaiusa.com/us/en/vehicles/elantra)


### PR DESCRIPTION
Add comprehensive article covering Apple CarPlay and Android Auto support across all Elantra model years (2016-2025). Highlights the unique configuration where base models with 8-inch screens have wireless connectivity while premium models with 10.25-inch screens require wired connections.