### PR TITLE
Write Nissan Rogue model article

### DIFF
--- a/articles/nissan/rogue/about.md
+++ b/articles/nissan/rogue/about.md
@@ -1,0 +1,47 @@
+# About the Nissan Rogue
+
+The Nissan Rogue is a compact crossover SUV that has been Nissan's best-selling vehicle in the United States since its introduction in 2007. The current third generation, launched in 2021, features modern connectivity options including wireless smartphone integration on higher trim levels.
+
+## Frequently Asked Questions
+
+### Does the Nissan Rogue support Apple CarPlay and Android Auto?
+
+Apple CarPlay and Android Auto support varies by model year and trim level:
+
+**2024-2025 Models (Third Generation):**
+
+- **Wireless** Apple CarPlay and Android Auto on SL and Platinum trims
+- **Wired** Apple CarPlay and Android Auto on S, SV, and Rock Creek trims
+- 12.3-inch touchscreen with Google Built-in on SL and Platinum trims
+- 8-inch touchscreen on S, SV, and Rock Creek trims
+- Wireless charging pad available on SL and Platinum trims
+
+**2021-2023 Models (Third Generation):**
+
+- **Wireless** Apple CarPlay and Android Auto on SL and Platinum trims only
+- **Wired** Apple CarPlay and Android Auto on S and SV trims
+- 12.3-inch touchscreen on higher trims, 8-inch touchscreen on base trims
+- Wireless connectivity requires the larger screen and premium trim levels
+
+**2018-2020 Models (Second Generation):**
+
+- **Wired** Apple CarPlay and Android Auto standard across all trims starting with 2018 model year
+- USB connection required for smartphone integration
+- 8-inch touchscreen with NissanConnect infotainment system
+- 2018 was the first model year to offer factory Apple CarPlay and Android Auto
+
+**2014-2017 Models (Second Generation):**
+
+- No factory Apple CarPlay or Android Auto support
+- Aftermarket modules and head unit replacements available to add smartphone integration
+- Plug-and-play adapters can integrate with some factory touchscreens
+- Complete head unit replacement offers the most features but requires more extensive installation
+
+**2008-2013 Models (First Generation):**
+
+- No smartphone integration support
+- Aftermarket head unit replacement required for CarPlay and Android Auto functionality
+
+The third-generation Rogue introduced wireless smartphone integration as a premium feature, allowing SL and Platinum owners to connect their devices without cables when combined with the available wireless charging pad.
+
+[Learn more about Nissan Rogue connectivity features](https://www.nissanusa.com/vehicles/crossovers-suvs/rogue.html)


### PR DESCRIPTION
Add comprehensive article covering Apple CarPlay and Android Auto support across all Nissan Rogue model years (2008-2025). Article includes detailed breakdown of wireless vs wired connectivity by generation and trim level, screen sizes, and aftermarket options for older models.