### PR TITLE
Write Ford Taurus model article

### DIFF
--- a/articles/ford/taurus/about.md
+++ b/articles/ford/taurus/about.md
@@ -1,0 +1,29 @@
+# About the Ford Taurus
+
+The Ford Taurus is a full-size sedan that was produced by Ford from 1986 to 2019. Originally introduced as a revolutionary aerodynamic design that helped revitalize Ford in the 1980s, the Taurus became one of America's best-selling sedans before production ended in March 2019.
+
+## Frequently Asked Questions
+
+### Does the Ford Taurus support Apple CarPlay and Android Auto?
+
+Yes, Ford Taurus models equipped with SYNC 3 support both Apple CarPlay and Android Auto, though availability varies by model year and trim level.
+
+**2017-2019 Models (with SYNC 3):**
+- **Wired** Apple CarPlay and Android Auto
+- 8-inch touchscreen display
+- USB cable connection required (Lightning to USB for iPhone)
+- SYNC 3 was standard on Limited and SHO trims, optional on SEL trim (via Equipment Group 201A package)
+- Base SE trim came with SYNC 1 or SYNC 2, without CarPlay/Android Auto support
+
+**2016 Models (with SYNC 3):**
+- **Wired** Apple CarPlay and Android Auto available via software update to SYNC 3 version 2.2
+- Could be updated via USB drive, dealer installation, or Wi-Fi connection
+- Same trim level availability as 2017-2019 models
+
+**2015 and Earlier:**
+- No factory Apple CarPlay or Android Auto support
+- Aftermarket solutions and SYNC 3 upgrade kits available
+
+The Ford Taurus was discontinued after the 2019 model year as Ford shifted focus to SUVs and trucks. For models with only wired connectivity, aftermarket wireless adapters are available that plug into the existing USB port and enable wireless functionality without any modification to the vehicle.
+
+For more information about the Ford Taurus and its history, visit the [Ford Taurus Wikipedia page](https://en.wikipedia.org/wiki/Ford_Taurus).


### PR DESCRIPTION
Add comprehensive article about Ford Taurus Apple CarPlay and Android Auto support. Article covers:
- Wired CarPlay/Android Auto support on 2016-2019 models with SYNC 3
- Trim level availability (standard on Limited/SHO, optional on SEL)
- Model year breakdowns and software update information for 2016 models
- Notes about vehicle discontinuation in 2019

Follows sidecar-content-strategy focusing exclusively on connectivity features.